### PR TITLE
EpgRetrieverワーカーの作成

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
 name = "domain"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
 ]
@@ -1341,6 +1342,7 @@ dependencies = [
 name = "kurec"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "clap",
  "domain",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ dependencies = [
  "async-trait",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/rust/bin/kurec/Cargo.toml
+++ b/rust/bin/kurec/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+async-trait = "0.1.88"

--- a/rust/bin/kurec/src/main.rs
+++ b/rust/bin/kurec/src/main.rs
@@ -199,6 +199,7 @@ async fn process_epg_retriever(mirakc_url: &str, nats_url: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use domain::error::DomainError;
     use domain::model::event::recording::{epg, programs};
     use domain::model::program::{Channel, Genre, Program, ProgramIdentifiers, ProgramTiming};
     use domain::ports::ProgramsRetriever;

--- a/rust/bin/kurec/src/main.rs
+++ b/rust/bin/kurec/src/main.rs
@@ -1,15 +1,16 @@
 use std::vec;
 
 use clap::{Parser, Subcommand};
-use domain::model::event::recording::epg::EpgUpdated;
+use domain::model::event::recording::epg::Updated;
+use domain::ports::ProgramsRetriever;
 use futures::StreamExt as _;
 use mirakc::get_mirakc_event_stream;
 use nats::{
     nats::connect_nats,
-    stream::EventStore,
+    stream::{EventReader, EventStore},
     stream_manager::{StreamConfig, create_or_update_streams},
 };
-use tracing::debug;
+use tracing::{debug, error};
 use tracing_subscriber::{EnvFilter, fmt};
 
 #[derive(Parser)]
@@ -36,7 +37,15 @@ enum Commands {
         #[arg(short, long, default_value_t = 5)]
         retry_max: u32,
     },
-    // 将来的に他のコマンドを追加する予定
+    EpgRetriever {
+        /// mirakcサーバーのURL
+        #[arg(short, long, default_value = "http://tuner:40772")]
+        mirakc_url: String,
+
+        /// NATSサーバーのURL
+        #[arg(short, long, default_value = "nats:4222")]
+        nats_url: String,
+    },
 }
 
 #[tokio::main]
@@ -56,7 +65,31 @@ async fn main() {
         } => {
             process_events(mirakc_url, nats_url, *retry_max).await;
         }
+        Commands::EpgRetriever {
+            mirakc_url,
+            nats_url,
+        } => {
+            process_epg_retriever(mirakc_url, nats_url).await;
+        }
     }
+}
+
+async fn setup_kurec_streams(
+    nats_client: &nats::nats::NatsClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let kurec_stream_config = StreamConfig {
+        name: "kurec".to_string(),
+        subjects: vec![
+            "recording.>".to_string(), // すべてのrecordingイベントをカバー
+        ],
+        ..Default::default()
+    };
+
+    let stream_configs = vec![kurec_stream_config];
+
+    create_or_update_streams(nats_client, &stream_configs).await?;
+
+    Ok(())
 }
 
 async fn process_events(mirakc_url: &str, nats_url: &str, retry_max: u32) {
@@ -64,19 +97,11 @@ async fn process_events(mirakc_url: &str, nats_url: &str, retry_max: u32) {
         .await
         .unwrap();
     let nats_client = connect_nats(nats_url).await.unwrap();
-    let event_store = EventStore::<EpgUpdated>::new(nats_client.clone())
+    let event_store = EventStore::<Updated>::new(nats_client.clone())
         .await
         .unwrap();
 
-    let stream_config_list = vec![StreamConfig {
-        name: "kurec".to_string(),
-        subjects: vec!["recording.>".to_string()],
-        ..Default::default()
-    }];
-
-    create_or_update_streams(&nats_client, &stream_config_list)
-        .await
-        .unwrap();
+    setup_kurec_streams(&nats_client).await.unwrap();
 
     while let Some(event) = sse_stream.next().await {
         debug!("Received event: {:?}", event);
@@ -87,7 +112,7 @@ async fn process_events(mirakc_url: &str, nats_url: &str, retry_max: u32) {
                 match ev {
                     Ok(ev) => {
                         debug!("Parsed event: {:?}", ev);
-                        let domain_ev = EpgUpdated {
+                        let domain_ev = Updated {
                             service_id: ev.service_id,
                         };
                         event_store.publish_event(&domain_ev).await.unwrap();
@@ -104,5 +129,244 @@ async fn process_events(mirakc_url: &str, nats_url: &str, retry_max: u32) {
                 debug!("Unknown event type: {:?}", event.event_type);
             }
         }
+    }
+}
+
+async fn process_epg_retriever(mirakc_url: &str, nats_url: &str) {
+    use domain::model::event::recording::{epg, programs};
+    use mirakc::MirakcProgramsRetriever;
+
+    debug!("EPGリトリーバーを開始します...");
+    let nats_client = connect_nats(nats_url).await.unwrap();
+
+    let epg_event_store = EventStore::<epg::Updated>::new(nats_client.clone())
+        .await
+        .unwrap();
+    let programs_event_store = EventStore::<programs::Updated>::new(nats_client.clone())
+        .await
+        .unwrap();
+
+    setup_kurec_streams(&nats_client).await.unwrap();
+
+    let reader = epg_event_store
+        .get_reader("epg-retriever".to_string())
+        .await
+        .unwrap();
+
+    let programs_retriever = MirakcProgramsRetriever::new(mirakc_url);
+
+    debug!("EPGイベント待機中...");
+
+    loop {
+        match reader.next().await {
+            Ok(event) => {
+                debug!("EPG更新イベントを受信: service_id={}", event.service_id);
+
+                let programs = programs_retriever.get_programs(event.service_id).await;
+                debug!(
+                    "サービスID {} のプログラム {} 件を取得",
+                    event.service_id,
+                    programs.len()
+                );
+
+                let programs_updated = programs::Updated {
+                    service_id: event.service_id,
+                    programs,
+                };
+
+                match programs_event_store.publish_event(&programs_updated).await {
+                    Ok(_) => debug!(
+                        "プログラム更新イベントを発行しました: service_id={}",
+                        event.service_id
+                    ),
+                    Err(e) => error!("プログラム更新イベントの発行に失敗: {:?}", e),
+                }
+            }
+            Err(e) => {
+                error!("EPGイベントの受信に失敗: {:?}", e);
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use domain::model::event::recording::{epg, programs};
+    use domain::model::program::{Channel, Genre, Program, ProgramIdentifiers, ProgramTiming};
+    use domain::ports::ProgramsRetriever;
+    use std::sync::{Arc, Mutex};
+
+    struct MockProgramsRetriever {
+        service_id: i64,
+        programs: Vec<Program>,
+    }
+
+    #[async_trait::async_trait]
+    impl ProgramsRetriever for MockProgramsRetriever {
+        async fn get_programs(&self, service_id: i64) -> Vec<Program> {
+            if service_id == self.service_id {
+                self.programs.clone()
+            } else {
+                Vec::new()
+            }
+        }
+    }
+
+    struct MockEventReader<T> {
+        events: Vec<T>,
+        current: usize,
+    }
+
+    impl<T: Clone> MockEventReader<T> {
+        fn new(events: Vec<T>) -> Self {
+            Self { events, current: 0 }
+        }
+
+        async fn next(&mut self) -> Result<T, String> {
+            if self.current < self.events.len() {
+                let event = self.events[self.current].clone();
+                self.current += 1;
+                Ok(event)
+            } else {
+                Err("イベントがありません".to_string())
+            }
+        }
+    }
+
+    struct MockEventStore<T> {
+        published_events: Arc<Mutex<Vec<T>>>,
+    }
+
+    impl<T: Clone> MockEventStore<T> {
+        fn new() -> Self {
+            Self {
+                published_events: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        async fn publish_event(&self, event: &T) -> Result<(), String> {
+            self.published_events.lock().unwrap().push(event.clone());
+            Ok(())
+        }
+
+        fn get_published_events(&self) -> Vec<T> {
+            self.published_events.lock().unwrap().clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_epg_retriever_logic() {
+        let service_id = 1;
+        let service_id_i32 = service_id as i32; // i64からi32への変換
+
+        let test_program = Program::new(
+            ProgramIdentifiers {
+                id: 123456789,
+                event_id: 1234,
+                network_id: 5678,
+                service_id: service_id_i32,
+            },
+            ProgramTiming {
+                start_at: 1619856000000,
+                duration: 1800000,
+            },
+            true,                                 // is_free
+            Some("テスト番組".to_string()),       // name
+            Some("テスト番組の説明".to_string()), // description
+            vec![Genre { lv1: 7, lv2: 0 }],       // genres
+            Channel {
+                id: service_id,
+                name: "テストチャンネル".to_string(),
+            },
+        );
+
+        let mock_retriever = MockProgramsRetriever {
+            service_id,
+            programs: vec![test_program.clone()],
+        };
+
+        let epg_updated = epg::Updated { service_id };
+
+        let programs = mock_retriever.get_programs(epg_updated.service_id).await;
+
+        let programs_updated = programs::Updated {
+            service_id: epg_updated.service_id,
+            programs,
+        };
+
+        assert_eq!(programs_updated.service_id, service_id);
+        assert_eq!(programs_updated.programs.len(), 1);
+
+        let program = &programs_updated.programs[0];
+        assert_eq!(program.id, 123456789);
+        assert_eq!(program.service_id, service_id_i32);
+        assert_eq!(program.name, Some("テスト番組".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_process_epg_retriever_with_mocks() {
+        let service_id = 1;
+        let service_id_i32 = service_id as i32;
+
+        let test_program = Program::new(
+            ProgramIdentifiers {
+                id: 123456789,
+                event_id: 1234,
+                network_id: 5678,
+                service_id: service_id_i32,
+            },
+            ProgramTiming {
+                start_at: 1619856000000,
+                duration: 1800000,
+            },
+            true,
+            Some("テスト番組".to_string()),
+            Some("テスト番組の説明".to_string()),
+            vec![Genre { lv1: 7, lv2: 0 }],
+            Channel {
+                id: service_id,
+                name: "テストチャンネル".to_string(),
+            },
+        );
+
+        let mock_retriever = MockProgramsRetriever {
+            service_id,
+            programs: vec![test_program.clone()],
+        };
+
+        let epg_updated = epg::Updated { service_id };
+
+        let mut mock_reader = MockEventReader::new(vec![epg_updated.clone()]);
+
+        let mock_event_store = MockEventStore::<programs::Updated>::new();
+
+        // process_epg_retrieverの主要なロジックを再現
+        let event = mock_reader.next().await.unwrap();
+
+        let programs = mock_retriever.get_programs(event.service_id).await;
+
+        let programs_updated = programs::Updated {
+            service_id: event.service_id,
+            programs,
+        };
+
+        mock_event_store
+            .publish_event(&programs_updated)
+            .await
+            .unwrap();
+
+        let published_events = mock_event_store.get_published_events();
+        assert_eq!(published_events.len(), 1);
+
+        let published_event = &published_events[0];
+        assert_eq!(published_event.service_id, service_id);
+        assert_eq!(published_event.programs.len(), 1);
+
+        let program = &published_event.programs[0];
+        assert_eq!(program.id, 123456789);
+        assert_eq!(program.service_id, service_id_i32);
+        assert_eq!(program.name, Some("テスト番組".to_string()));
     }
 }

--- a/rust/libs/domain/Cargo.toml
+++ b/rust/libs/domain/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.126", features = ["preserve_order"] }
 async-trait = "0.1.88"
+thiserror = "2.0.12"

--- a/rust/libs/domain/Cargo.toml
+++ b/rust/libs/domain/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.126", features = ["preserve_order"] }
+async-trait = "0.1.88"

--- a/rust/libs/domain/src/error.rs
+++ b/rust/libs/domain/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DomainError {
+    #[error("プログラム取得エラー: {0}")]
+    ProgramsRetrievalError(String),
+
+    #[error("サービス(ID={0})が見つかりません")]
+    ServiceNotFound(i64),
+
+    #[error("不明なエラー: {0}")]
+    UnknownError(String),
+}

--- a/rust/libs/domain/src/lib.rs
+++ b/rust/libs/domain/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod model;
 pub mod ports;
 pub mod types;

--- a/rust/libs/domain/src/model/event.rs
+++ b/rust/libs/domain/src/model/event.rs
@@ -5,9 +5,21 @@ pub mod recording {
         use crate::types::Event;
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct EpgUpdated {
+        pub struct Updated {
             pub service_id: i64,
         }
-        impl Event for EpgUpdated {}
+        impl Event for Updated {}
+    }
+    pub mod programs {
+        use serde::{Deserialize, Serialize};
+
+        use crate::{model::program::Program, types::Event};
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct Updated {
+            pub service_id: i64,
+            pub programs: Vec<Program>,
+        }
+        impl Event for Updated {}
     }
 }

--- a/rust/libs/domain/src/ports/programs_retriever.rs
+++ b/rust/libs/domain/src/ports/programs_retriever.rs
@@ -1,5 +1,6 @@
 use crate::model::program::Program;
 
+#[async_trait::async_trait]
 pub trait ProgramsRetriever {
-    fn get_programs(&self, service_id: i64) -> Vec<Program>;
+    async fn get_programs(&self, service_id: i64) -> Vec<Program>;
 }

--- a/rust/libs/domain/src/ports/programs_retriever.rs
+++ b/rust/libs/domain/src/ports/programs_retriever.rs
@@ -1,6 +1,7 @@
+use crate::error::DomainError;
 use crate::model::program::Program;
 
 #[async_trait::async_trait]
 pub trait ProgramsRetriever {
-    async fn get_programs(&self, service_id: i64) -> Vec<Program>;
+    async fn get_programs(&self, service_id: i64) -> Result<Vec<Program>, DomainError>;
 }

--- a/rust/libs/infra/mirakc/src/http_client.rs
+++ b/rust/libs/infra/mirakc/src/http_client.rs
@@ -210,73 +210,74 @@ mod tests {
             }
         });
 
-        let programs_route = warp::path!("api" / "services" / i64 / "programs").map(|service_id: i64| {
-            let programs = vec![json!({
-                "id": 1,
-                "eventId": 1001,
-                "serviceId": service_id,
-                "networkId": 1,
-                "startAt": 1619856000000i64,
-                "duration": 1800000,
-                "isFree": true,
-                "name": "テスト番組1",
-                "description": "テスト番組の説明1",
-                "extended": {
-                    "概要": "テスト番組の概要です",
-                    "出演者": "テスト出演者1\nテスト出演者2"
-                },
-                "video": {
-                    "type": "mpeg2",
-                    "resolution": "1080i",
-                    "streamContent": 1,
-                    "componentType": 179
-                },
-                "audio": {
-                    "componentType": 3,
-                    "isMain": true,
-                    "samplingRate": 48000,
-                    "langs": [
-                        "jpn"
-                    ]
-                },
-                "audios": [
-                    {
+        let programs_route =
+            warp::path!("api" / "services" / i64 / "programs").map(|service_id: i64| {
+                let programs = vec![json!({
+                    "id": 1,
+                    "eventId": 1001,
+                    "serviceId": service_id,
+                    "networkId": 1,
+                    "startAt": 1619856000000i64,
+                    "duration": 1800000,
+                    "isFree": true,
+                    "name": "テスト番組1",
+                    "description": "テスト番組の説明1",
+                    "extended": {
+                        "概要": "テスト番組の概要です",
+                        "出演者": "テスト出演者1\nテスト出演者2"
+                    },
+                    "video": {
+                        "type": "mpeg2",
+                        "resolution": "1080i",
+                        "streamContent": 1,
+                        "componentType": 179
+                    },
+                    "audio": {
                         "componentType": 3,
                         "isMain": true,
                         "samplingRate": 48000,
                         "langs": [
                             "jpn"
                         ]
-                    }
-                ],
-                "genres": [
-                    {
-                        "lv1": 7,
-                        "lv2": 0,
-                        "un1": 15,
-                        "un2": 15
-                    }
-                ],
-                "relatedItems": [
-                    {
-                        "type": "shared",
-                        "networkId": null,
-                        "serviceId": 1,
-                        "eventId": 1001
                     },
-                    {
-                        "type": "shared",
-                        "networkId": null,
-                        "serviceId": 2,
-                        "eventId": 1001
-                    }
-                ]
-            })];
+                    "audios": [
+                        {
+                            "componentType": 3,
+                            "isMain": true,
+                            "samplingRate": 48000,
+                            "langs": [
+                                "jpn"
+                            ]
+                        }
+                    ],
+                    "genres": [
+                        {
+                            "lv1": 7,
+                            "lv2": 0,
+                            "un1": 15,
+                            "un2": 15
+                        }
+                    ],
+                    "relatedItems": [
+                        {
+                            "type": "shared",
+                            "networkId": null,
+                            "serviceId": 1,
+                            "eventId": 1001
+                        },
+                        {
+                            "type": "shared",
+                            "networkId": null,
+                            "serviceId": 2,
+                            "eventId": 1001
+                        }
+                    ]
+                })];
 
-            Response::builder()
-                .header("content-type", "application/json")
-                .body(serde_json::to_string(&programs).unwrap())
-        });
+                Response::builder()
+                    .header("content-type", "application/json")
+                    .body(serde_json::to_string(&programs).unwrap())
+            });
 
         let routes = service_route.or(programs_route);
 

--- a/rust/libs/infra/mirakc/src/http_client.rs
+++ b/rust/libs/infra/mirakc/src/http_client.rs
@@ -38,7 +38,7 @@ impl MirakcApiClient {
         &self,
         service_id: i64,
     ) -> Result<Vec<MirakurunProgram>, MirakcApiError> {
-        let url = format!("{}/services/{}/programs", self.base_url, service_id);
+        let url = format!("{}/api/services/{}/programs", self.base_url, service_id);
         debug!("Fetching programs from: {}", url);
 
         let response = self.client.get(&url).send().await?;
@@ -64,7 +64,7 @@ impl MirakcApiClient {
     }
 
     pub async fn get_service(&self, service_id: i64) -> Result<MirakurunService, MirakcApiError> {
-        let url = format!("{}/services/{}", self.base_url, service_id);
+        let url = format!("{}/api/services/{}", self.base_url, service_id);
         debug!("Fetching service from: {}", url);
 
         let response = self.client.get(&url).send().await?;
@@ -190,7 +190,7 @@ mod tests {
     fn create_mock_server() -> (String, oneshot::Sender<()>) {
         let (tx, rx) = oneshot::channel();
 
-        let service_route = warp::path!("services" / i64).map(|service_id: i64| {
+        let service_route = warp::path!("api" / "services" / i64).map(|service_id: i64| {
             if service_id == 1 || service_id == 23608 {
                 let service = json!({
                     "id": service_id,
@@ -210,7 +210,7 @@ mod tests {
             }
         });
 
-        let programs_route = warp::path!("services" / i64 / "programs").map(|service_id: i64| {
+        let programs_route = warp::path!("api" / "services" / i64 / "programs").map(|service_id: i64| {
             let programs = vec![json!({
                 "id": 1,
                 "eventId": 1001,

--- a/rust/libs/infra/mirakc/src/programs_retriever.rs
+++ b/rust/libs/infra/mirakc/src/programs_retriever.rs
@@ -314,7 +314,7 @@ mod mock_tests {
     fn create_mock_server() -> (String, oneshot::Sender<()>) {
         let (tx, rx) = oneshot::channel();
 
-        let service_route = warp::path!("services" / i64).map(|service_id: i64| {
+        let service_route = warp::path!("api" / "services" / i64).map(|service_id: i64| {
             let service = json!({
                 "id": service_id,
                 "serviceId": service_id,
@@ -328,7 +328,7 @@ mod mock_tests {
                 .body(serde_json::to_string(&service).unwrap())
         });
 
-        let programs_route = warp::path!("services" / i64 / "programs")
+        let programs_route = warp::path!("api" / "services" / i64 / "programs")
             .map(|service_id: i64| {
                 let programs = vec![
                     json!({


### PR DESCRIPTION
下記を行うワーカーを作成する
- イベントはrust/libs/domain/src/model/event.rs に定義されている
- 今回使うポートはrust/libs/domain/src/ports/programs_retriever.rsに定義されている
- recording::epg::Updatedイベントを受け取って、MirakcProgramsRetrieverを使ってservice_idに対応するVec<Program>を得て、recording::programs::Updatedイベントに入れてNATS JetStreamに発行する

注意点
- main.rsでclapのコマンドとして実装
- このような「イベントを読み取って変換して別のイベントにして発行する」処理は今後多発するので共通化する
- イベントからイベントの変換はドメイン層に実装する
- イベントの読み取り・発行処理はインフラ層が実際の処理を行う
- アプリケーション層でそれらを接続する